### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple usage example.
 
 ``` toit
 import gpio
-import serial.protocols.i2c as i2c
+import i2c
 import vcnl4040 show Vcnl4040
 
 main:


### PR DESCRIPTION
The VCNL4040 readme example does not compile. 

```
Running 'vcnl.toit' on 'usual-north' ...
vcnl.toit:2:1: error: Failed to import 'serial.protocols.i2c'
import serial.protocols.i2c as i2c
^~~~~~
vcnl.toit:2:15: note: Cannot enter '<sdk>/serial/protocols': folder does not exist
import serial.protocols.i2c as i2c
              ^~~~~~~~~
vcnl.toit:6:14: error: Unresolved identifier: 'Bus'
  bus := i2c.Bus
             ^~~
Compilation failed.
```

You have corrected it in _examples_, but not here.