### PR TITLE
Migrate GPIO construction for SDK 2.0.0-alpha.196

### DIFF
--- a/examples/vcnl4040.toit
+++ b/examples/vcnl4040.toit
@@ -6,14 +6,13 @@
 A simple example of how to use the VCNL4040 driver.
 */
 
-import gpio
 import i2c
 import vcnl4040 show Vcnl4040
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
     --frequency=1000
   
   device := bus.device Vcnl4040.I2C-ADDRESS

--- a/package.yaml
+++ b/package.yaml
@@ -2,4 +2,4 @@ name: vcnl4040
 description: A low level driver for the VCNL4040 sensor.
 
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196

--- a/package.yaml
+++ b/package.yaml
@@ -2,4 +2,4 @@ name: vcnl4040
 description: A low level driver for the VCNL4040 sensor.
 
 environment:
-  sdk: ^2.0.0-alpha.144
+  sdk: ^2.0.0-alpha.194.1


### PR DESCRIPTION
## Summary

- update GPIO/peripheral construction for the SDK integer-pin API
- require Toit SDK `^2.0.0-alpha.196`
- modernize the package publish workflow where needed

Part of the SDK 196 package migration.