### PR TITLE
Add missing package specification

### DIFF
--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  vcnl4040:
+    path: ..


### PR DESCRIPTION
## Summary

- add package specifications for lock-only example or test projects
- declare each project's local dependency on the parent package
- allow the projects to be installed when discovered by OpenToit's external test setup

## Testing

- `toit pkg install --no-auto-sync --project-root=<affected-project>`
